### PR TITLE
changes for Docker-only build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@ RUN apt-get update
 RUN apt-get -y install curl gnupg
 RUN curl -sL https://deb.nodesource.com/setup_11.x  | bash -
 RUN apt-get -y install nodejs
-COPY requirements.txt /opt/app/requirements.txt
 WORKDIR /opt/app
-RUN pip install -r /opt/app/requirements.txt
-COPY . /opt/app
-RUN python manage.py migrate
-RUN npm install
 EXPOSE 7501
-CMD npm start & python /opt/app/manage.py runserver 0:7501
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -3,34 +3,15 @@ Simple setup for a React-Django web app. See tutorial here: https://alphacoder.x
 
 ## Setup
 - Download/clone repo.
-- Windows users must follow below, non-windows users can either follow below or run `setup.sh`
-- Install python3
-- - (Windows) https://www.python.org/downloads/windows/
-- Install npm
-- - (Windows) https://nodejs.org/en/download/
-- - (Mac) https://nodejs.org/en/download/ OR https://treehouse.github.io/installation-guides/mac/node-mac.html
-- - (Unix) `sudo apt install npm`
-- Navigate to cloned repo in shell
-- Create a virtual environment.
-- - `pip3 install virtualenv`
-- - `python3 -m venv env`
-- Activate virtualenv
-- - (Windows) `.\env\Scripts\activate`
-- - (Other) `source env/bin/activate`
-- Install Django and other dependencies with `pip3 install -r requirements.txt`.
-- Run Django migrations using `python3 manage.py migrate`
-- Install React dependencies with `npm install`.
-
-## Alternative Setup for Windows:
-- Download/clone repo.
 - Download/install Docker https://docs.docker.com/docker-for-windows/install/
-- In a shell, navigate to repo
-- Build docker container `docker build -t test_repo .`
 
 ## Run
-- Run server:
-- - (Normally) `npm start & python3 manage.py runserver 0:7501`.
-- - (Using docker method for windows)
-- - - (using native shell) `docker run -it -p 7501:7501 -v "%cd%"\src:/opt/app/src -v "%cd%"\sampleapp:/opt/app/sampleapp test_repo`
-- - - (using unix style shell [might be able to omit 'winpty' from some, but this works on git bash]) `winpty docker run -it -p 7501:7501 -v "$(pwd)"/src:/opt/app/src -v "$(pwd)"/sampleapp:/opt/app/sampleapp test_repo`
-- Go to page in browser at `localhost:7501`, and then modify code as desired!
+- run the docker container: `$ docker run -it --volume path/to/repo:/opt/app -p 7501:7501 cyclica/interview`
+- from within the container shell:
+```
+$ chmod +x setup.sh
+$ ./setup.sh
+$ chmod +x runserver
+$ ./runserver
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django>=2.0.8
+PyDictionary

--- a/runserver
+++ b/runserver
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm start & python3 /opt/app/manage.py runserver 0:7501

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-	brew install node
-else
-	sudo apt install npm
-fi
-
-pip3 install virtualenv
-python3 -m venv env
-source env/bin/activate
 pip3 install -r requirements.txt
 python3 manage.py migrate
 npm install


### PR DESCRIPTION
focus on docker only for running the code, less possible variations in the user's dev environment.  They will need to come to the interview with Docker pre-installed.